### PR TITLE
Changed default font (fixed #1).

### DIFF
--- a/preamble.tex
+++ b/preamble.tex
@@ -9,6 +9,7 @@
 % Limba română
 \usepackage{polyglossia}
 \setdefaultlanguage{romanian}
+\setotherlanguages{english,russian}
 
 % Marginile paginii
 \usepackage{geometry}
@@ -22,8 +23,8 @@
 
 % Fonturi, xelatex
 \defaultfontfeatures{Ligatures=TeX}
-\setmainfont{Times New Roman}
-\newfontfamily\cyrillicfont{Times New Roman}
+\setmainfont{Tinos} % Analog pentru Times New Roman
+\newfontfamily\cyrillicfont{Tinos}
 \setmonofont{FreeMono} % Font pepntru codul sursă
 
 % Formule


### PR DESCRIPTION
Pentru preambulă se folosea fontul **Times New Roman**. Fiind un font proprietar, el trebuia de instalat pe sistemul de operare Linux (în cazul meu, în container Docker).

Acest font avea [probleme](https://en.wikipedia.org/wiki/Romanian_alphabet#Comma-below_(%C8%99_and_%C8%9B)_versus_cedilla_(%C5%9F_and_%C5%A3)) cu afișarea pe ecran a diacriticilor „[ș](https://en.wikipedia.org/wiki/S-comma)“ și „[ț](https://en.wikipedia.org/wiki/T-comma)“. Aceste diacritice folosesc virgula subt literele latine „s“ și „t“, în loc de simbolul [cedilla](https://en.wikipedia.org/wiki/Cedilla). Fontul instalat pe SO Linux nu poate afișa corect diacriticile române cu virgulă dedesubt.

Ca remediu al acestei probleme a servit modificarea fontului proprietar **Times New Roman** în fontul liber **Tinos**.